### PR TITLE
Install Or Update Dependabot to support Docker and Gomods

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,21 +1,24 @@
----
 version: 2
 updates:
 - package-ecosystem: gomod
-  directory: "/"
+  directory: /
   schedule:
     interval: daily
   labels:
-    - "area/dependency"
-    - "release-note-none"
-    - "ok-to-test"
+  - area/dependency
+  - release-note-none
+  - ok-to-test
   open-pull-requests-limit: 10
-- package-ecosystem: "github-actions"
-  directory: "/"
+- package-ecosystem: github-actions
+  directory: /
   schedule:
-      interval: "daily"
+    interval: daily
   labels:
-    - "area/dependency"
-    - "release-note-none"
-    - "ok-to-test"
+  - area/dependency
+  - release-note-none
+  - ok-to-test
   open-pull-requests-limit: 10
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: daily


### PR DESCRIPTION

Enable Dependabot for Docker and GoMod if not already so.
Keeping K8s dependencies up-to-date. 

This PR is created by bot.

Signed-off-by: zhuxiaow@google.com
